### PR TITLE
Update help docs with required arguments

### DIFF
--- a/doc/commands/gocan_app.md
+++ b/doc/commands/gocan_app.md
@@ -3,7 +3,7 @@
 Get an application summary information
 
 ```
-gocan app [flags]
+gocan app <app-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_code-age.md
+++ b/doc/commands/gocan_code-age.md
@@ -3,7 +3,7 @@
 Retrieve the age of the entities in months
 
 ```
-gocan code-age [flags]
+gocan code-age <app-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_code-churn.md
+++ b/doc/commands/gocan_code-churn.md
@@ -3,7 +3,7 @@
 Get the code churn of an application
 
 ```
-gocan code-churn [flags]
+gocan code-churn <app-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_complexity-analysis.md
+++ b/doc/commands/gocan_complexity-analysis.md
@@ -3,7 +3,7 @@
 Retrieve a complexity analysis by its name
 
 ```
-gocan complexity-analysis [flags]
+gocan complexity-analysis <file-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_coupling.md
+++ b/doc/commands/gocan_coupling.md
@@ -3,7 +3,7 @@
 Get the coupling relationships between entities for a given application
 
 ```
-gocan coupling [flags]
+gocan coupling <app-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_create-app.md
+++ b/doc/commands/gocan_create-app.md
@@ -3,7 +3,7 @@
 Create an application in a scene
 
 ```
-gocan create-app [flags]
+gocan create-app <app-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_create-boundaries.md
+++ b/doc/commands/gocan_create-boundaries.md
@@ -12,7 +12,7 @@ the different layers of an application. Or you can define a boundary for product
 
 
 ```
-gocan create-boundaries [flags]
+gocan create-boundaries <boundary-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_create-complexity-analysis.md
+++ b/doc/commands/gocan_create-complexity-analysis.md
@@ -10,7 +10,7 @@ the specified entity.
 
 
 ```
-gocan create-complexity-analysis [flags]
+gocan create-complexity-analysis <analysis-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_create-scene.md
+++ b/doc/commands/gocan_create-scene.md
@@ -3,7 +3,7 @@
 Create a scene
 
 ```
-gocan create-scene [flags]
+gocan create-scene <scene-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_create-team.md
+++ b/doc/commands/gocan_create-team.md
@@ -3,7 +3,7 @@
 Create a team of developers with its members
 
 ```
-gocan create-team [flags]
+gocan create-team <team-name> [flags]
 ```
 
 ### Options

--- a/doc/commands/gocan_delete-app.md
+++ b/doc/commands/gocan_delete-app.md
@@ -3,7 +3,7 @@
 Delete an application
 
 ```
-gocan delete-app [flags]
+gocan delete-app <app-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_delete-boundary.md
+++ b/doc/commands/gocan_delete-boundary.md
@@ -3,7 +3,7 @@
 Delete an application boundary
 
 ```
-gocan delete-boundary [flags]
+gocan delete-boundary <boundary-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_delete-complexity-analysis.md
+++ b/doc/commands/gocan_delete-complexity-analysis.md
@@ -3,7 +3,7 @@
 Delete a complexity analysis
 
 ```
-gocan delete-complexity-analysis [flags]
+gocan delete-complexity-analysis <analysis-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_delete-scene.md
+++ b/doc/commands/gocan_delete-scene.md
@@ -3,7 +3,7 @@
 Delete the specified scene
 
 ```
-gocan delete-scene [flags]
+gocan delete-scene <scene-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_delete-team.md
+++ b/doc/commands/gocan_delete-team.md
@@ -3,7 +3,7 @@
 Delete a team and its members
 
 ```
-gocan delete-team [flags]
+gocan delete-team <team-name> [flags]
 ```
 
 ### Options

--- a/doc/commands/gocan_devs.md
+++ b/doc/commands/gocan_devs.md
@@ -3,7 +3,7 @@
 Get the developers of an application
 
 ```
-gocan devs [flags]
+gocan devs <app-name> [flags]
 ```
 
 ### Options

--- a/doc/commands/gocan_file-metrics.md
+++ b/doc/commands/gocan_file-metrics.md
@@ -3,7 +3,7 @@
 Get global file metrics for an application
 
 ```
-gocan file-metrics [flags]
+gocan file-metrics <app-name> [flags]
 ```
 
 ### Examples

--- a/doc/commands/gocan_hotspots.md
+++ b/doc/commands/gocan_hotspots.md
@@ -3,7 +3,13 @@
 Get the hotspots of an application in JSON formatted for d3.js
 
 ```
-gocan hotspots [flags]
+gocan hotspots <app-name> [flags]
+```
+
+### Examples
+
+```
+gocan hotspots myapp --scene myscene
 ```
 
 ### Options

--- a/doc/commands/gocan_storyboard.md
+++ b/doc/commands/gocan_storyboard.md
@@ -3,7 +3,13 @@
 Create a storyboard of visualizations
 
 ```
-gocan storyboard [flags]
+gocan storyboard <app-name> [flags]
+```
+
+### Examples
+
+```
+gocan storyboard myapp --scene myscene --filename /code/storyboard.avi --analysis hotspots --fps 8
 ```
 
 ### Options

--- a/doc/commands/gocan_sum-of-coupling.md
+++ b/doc/commands/gocan_sum-of-coupling.md
@@ -3,7 +3,7 @@
 Get a sum of coupling for an application
 
 ```
-gocan sum-of-coupling [flags]
+gocan sum-of-coupling <app-name> [flags]
 ```
 
 ### Examples


### PR DESCRIPTION
Most commands require the app name, which was not previously shown in the help documentation. The documentation has been updated based on either trial and error with gocan v0.2.3, or the examples provided.

This caused me quite a bit of confusion as the app didn't explain what the expected argument was - I had to delve into the code to understand what was needed when trying to use `gocan hotspots`. Hopefully this makes it clearer for new users.

Note that there are some commands that may still require `<app-name>`, but I didn't see an example for them or didn't use them myself to verify the correct syntax.